### PR TITLE
Allow JSON schema validation to use references to multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ Fails the test if the response body *does* match the provided regular expression
 Fails the test if the response body doesn't begin with the provided XSSI prefix. The prefix will
 also be stripped before the response body is parsed as JSON.
 
+#### .addJsonSchema(schemaPath)
+
+Adds a JSON schema (or an array of JSON schema) to be used later by $ref links in validateJson().
+Every schema added using this method needs to have an id property.
+
 #### .validateJson(schemaPath)
 
 Validates the response body against a JSON schema.  The validator is taken from the Chromium project

--- a/lib/options.js
+++ b/lib/options.js
@@ -34,6 +34,9 @@ function Options() {
   /** Array of functions that will be called to verify the response. */
   this._evaluators = []
 
+  /** Schema that we know about, which are added by addJsonSchema() */
+  this._jsonSchema = {}
+
   // NOTE: When adding options make sure to add a corresponding copy step in _copy below.
 }
 module.exports = Options
@@ -280,6 +283,55 @@ Options.prototype.expectXssiPrefix = function (prefix) {
 
 
 /**
+ * Reads a file that contains either a single JSON schema or an
+ * array of JSON schema, which are added to the list of types that
+ * are referenced by $ref.
+ *
+ * Unlike validateJson(), every schema processed by addJsonSchema
+ * must have an id.
+ *
+ * @param {string} schemaPath Path to the schema file.
+ * @return {Options} The instance.
+ */
+Options.prototype.addJsonSchema = function (schemaPath) {
+  if (config.rootSchemaPath) {
+    schemaPath = path.resolve(config.rootSchemaPath, schemaPath)
+  }
+
+  this.evaluate(function (test, res) {
+    var schemaFile, schemata
+
+    try {
+      schemaFile = fs.readFileSync(schemaPath, 'utf8')
+    } catch (e) {
+      test.fail('Invalid JSON File. Unable to open file: ' + schemaPath)
+      return
+    }
+
+    try {
+      schemata = JSON.parse(schemaFile)
+    } catch (e) {
+      test.fail('Invalid JSON File. JSON parsing failed.  ' + e.message)
+      return
+    }
+
+    schemata = Array.isArray(schemata) ? schemata : [schemata]
+
+    for (var i = 0; i < schemata.length; i++) {
+      var schema = schemata[i]
+      if (!schema.id) {
+        test.fail('JSON schema must have an id before calling addJsonSchema: ' + schema)
+        return
+      }
+      if (this._fixSchema(test, schema, false)) this._jsonSchema[schema.id] = schema
+    }
+  })
+
+  return this
+}
+
+
+/**
  * Validates the response against the JSON Schema in the provided file.
  * @param {string} schemaPath Path to the schema file.
  * @return {Options} The instance.
@@ -290,21 +342,7 @@ Options.prototype.validateJson = function (schemaPath) {
   }
 
   this.evaluate(function (test, res) {
-    if (!res.body) {
-      test.fail('Expected response body for JSON validation.')
-      return
-    }
-
-    var body = res.body.toString('utf8')
-    if (this._xssiPrefix) body = body.substr(this._xssiPrefix.length)
-
-    var json, schemaFile, schema
-    try {
-      json = JSON.parse(body)
-    } catch (e) {
-      test.fail('Invalid response body. JSON parsing failed.  ' + e.message)
-      return
-    }
+    var schemaFile, schema
 
     try {
       schemaFile = fs.readFileSync(schemaPath, 'utf8')
@@ -320,17 +358,39 @@ Options.prototype.validateJson = function (schemaPath) {
       return
     }
 
-    var validator = new JSONSchemaValidator()
-    validator.validate(json, schema);
-    if (validator.errors.length > 0) {
-      var errorMessage = ['Invalid response body. JSON Schema validation failed.']
-      for (var i = 0; i < validator.errors.length; i++) {
-        var error = validator.errors[i]
-        errorMessage.push('  Error @ /' + error.path + ': ' + error.message)
+    if (this._fixSchema(test, schema, false)) {
+      if (!res.body) {
+        test.fail('Expected response body for JSON validation.')
+        return
       }
-      test.fail(errorMessage.join(' '))
+
+      var body = res.body.toString('utf8')
+      if (this._xssiPrefix) body = body.substr(this._xssiPrefix.length)
+
+      var json
+      try {
+        json = JSON.parse(body)
+      } catch (e) {
+        test.fail('Invalid response body. JSON parsing failed.  ' + e.message)
+        return
+      }
+
+      var validator = new JSONSchemaValidator()
+      for (key in this._jsonSchema) {
+        validator.addTypes(this._jsonSchema[key])
+      }
+      validator.validate(json, schema);
+      if (validator.errors.length > 0) {
+        var errorMessage = ['Invalid response body. JSON Schema validation failed.']
+        for (var i = 0; i < validator.errors.length; i++) {
+          var error = validator.errors[i]
+          errorMessage.push('  Error @ /' + error.path + ': ' + error.message)
+        }
+        test.fail(errorMessage.join(' '))
+      }
     }
   })
+
   return this
 }
 
@@ -358,6 +418,7 @@ Options.prototype.getHeaders = function () {
 /**
  * Copies the settings from another Options object to this one. Intended for internal use only.
  * @param {Options} source
+ * @private
  */
 Options.prototype._copy = function (source) {
   this._headers = source.getHeaders()
@@ -366,4 +427,42 @@ Options.prototype._copy = function (source) {
   this._httpMethod = source._httpMethod
   this._xssiPrefix = source._xssiPrefix
   this._evaluators = source._evaluators.concat()
+  this._jsonSchema = source._jsonSchema
+}
+
+
+/**
+ * Private method that massages a JSON schema before passing to the
+ * chromium library.
+ *
+ * The chromium library expects 'pattern' to be a JavaScript RegExp
+ * object, which does not happen naturally as a result of a JSON.parse().
+ *
+ * @param {Object} test An object which exposes the nodeunit test interface.
+ * @param {Object} schema The json schema object to add to our internal map.
+ * @param {boolean} ignoreSpecialKeys True if special keys like 'pattern' should
+ *    be ignored, because we are in a context like 'properties' where
+ *    special keys no longer have their special meaning
+ * @return {boolean} True if the schema could be fixed. False if not.
+ * @private
+ */
+Options.prototype._fixSchema = function (test, schema, ignoreSpecialKeys) {
+  for (var key in schema) {
+    if (!ignoreSpecialKeys && key == 'pattern') {
+      try {
+        schema[key] = new RegExp(schema[key])
+      } catch (e) {
+        test.fail('Unable to create a regular expression for pattern ' + schema[key])
+        return false
+      }
+    } else if (typeof schema[key] === 'object') {
+      // We ignore special keys in the next layer if:
+      // 1) we are not in an "ignoreSpecialKeys" layer, and
+      // 2) the key we are about to process is "properties".
+      var ignoreSpecialKeysNextTime = !ignoreSpecialKeys && key == 'properties'
+      if (!this._fixSchema(test, schema[key], ignoreSpecialKeysNextTime)) return false
+    }
+  }
+
+  return true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falkor",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "keywords": [
     "javascript",
     "nodeunit",

--- a/tests/falkor_test.js
+++ b/tests/falkor_test.js
@@ -22,6 +22,8 @@ var nock = require('nock')
 var path = require('path')
 
 var testJsonSchemaPath = path.join(__dirname, 'test.schema.json')
+var testJsonSchemaPathToLoad = path.join(__dirname, 'testToLoad.schema.json')
+var testJsonSchemaPathWithRef = path.join(__dirname, 'testWithRef.schema.json')
 
 
 // Tear down after every test.
@@ -322,6 +324,53 @@ exports.testJsonSchemaValidation_success = function (test) {
   new falkor.TestCase('http://falkor.fake/jsonschema')
       .setAsserter(mockTest)
       .validateJson(testJsonSchemaPath)
+      .run()
+}
+
+
+// Tests that JSON that references another schema can fail.
+exports.testJsonSchemaWithRefs_badPattern = function (test) {
+  var mockTest = newMockTestWithExpectedFailure(test)
+
+  mockTest.verifyResponse(nock('http://falkor.fake')
+      .get('/jsonschema')
+      .reply(200, '{"id": 123, "title": "Tést Itëm", "content": { "text": "foo", "length": 3 }}'))
+
+  new falkor.TestCase('http://falkor.fake/jsonschema')
+      .setAsserter(mockTest)
+      .addJsonSchema(testJsonSchemaPathToLoad)
+      .validateJson(testJsonSchemaPathWithRef)
+      .run()
+}
+
+
+// Tests that JSON that references another schema can fail.
+exports.testJsonSchemaWithRefs_missingRef = function (test) {
+  var mockTest = newMockTestWithExpectedFailure(test)
+
+  mockTest.verifyResponse(nock('http://falkor.fake')
+      .get('/jsonschema')
+      .reply(200, '{"id": 123, "title": "Test Item", "content": { "text": "foo", "length": 3 }}'))
+
+  new falkor.TestCase('http://falkor.fake/jsonschema')
+      .setAsserter(mockTest)
+      .validateJson(testJsonSchemaPathWithRef)
+      .run()
+}
+
+
+// Tests that JSON that references another schema passes.
+exports.testJsonSchemaWithRefs_success = function (test) {
+  var mockTest = newMockTestWithNoAssertions(test)
+
+  mockTest.verifyResponse(nock('http://falkor.fake')
+      .get('/jsonschema')
+      .reply(200, '{"id": 123, "title": "Test Item", "content": { "text": "foo", "length": 3 }}'))
+
+  new falkor.TestCase('http://falkor.fake/jsonschema')
+      .setAsserter(mockTest)
+      .addJsonSchema(testJsonSchemaPathToLoad)
+      .validateJson(testJsonSchemaPathWithRef)
       .run()
 }
 

--- a/tests/testToLoad.schema.json
+++ b/tests/testToLoad.schema.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Title",
+    "id": "title",
+    "type": "string",
+    "pattern": "^[A-Za-z0-9 ]+$",
+    "required": true
+  },
+  {
+    "name": "Content",
+    "id": "content",
+    "type": "object",
+    "properties": {
+      "text": { "type": "string", "required": true },
+      "length": { "type": "number" }
+    }
+  }
+]

--- a/tests/testWithRef.schema.json
+++ b/tests/testWithRef.schema.json
@@ -1,0 +1,13 @@
+{
+ "name": "Test Item With Ref",
+ "type": "object",
+ "properties": {
+   "id": {
+     "type": "number",
+     "description": "Item identifier",
+     "required": true
+   },
+   "title": { "$ref": "title" },
+   "content": { "$ref": "content" }
+ }
+}


### PR DESCRIPTION
Hello dan, 

Please review the following commits I made in branch 'sho-multiple-json'.

I accidentally pushed this to master and then reverted the change.

Changes:

1) Allows you to addJsonSchema(file). This is important because...
2) validateJson(file) can only use a $ref if that $ref comes from
   another file, and...
3) Since that was being added, I added a validateJsonById() to
   validate against one of the schema that was added in (1).

Finally,

4) It turns out that the chromium library expects the "pattern"
   field to be a JavaScript RegExp, but that obviously won't happen
   just by doing a JSON.parse() of a text file, so I added some
   code to create a regexp from the value found in the file.

ae46f4b2e61c9c51d221f71155f7f9d7372b6ed9 (2012-10-22 21:31:07 -0700)
update version #

107b04bc0363faf883ad1f8002e22b2c47c0e290 (2012-10-22 21:29:37 -0700)
Allow JSON schema validation to use references to multiple files

R=dan
