### PR TITLE
Add special handling of "required" to work with our json schema library

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -241,6 +241,8 @@ Options.prototype.expectJsonWithCharset = function (opt_charset) {
  */
 Options.prototype.expectBodyMatches = function (re) {
   this.evaluate(function (test, res) {
+    console.log(res.body.toString())
+
     test.ok(re.test(res.body ? res.body.toString('utf8') : ''),
         'Expected response body to match ' + re.toString())
   })
@@ -455,6 +457,10 @@ Options.prototype._fixSchema = function (test, schema, ignoreSpecialKeys) {
         test.fail('Unable to create a regular expression for pattern ' + schema[key])
         return false
       }
+    } else if (!ignoreSpecialKeys && key == 'required') {
+      // The current version of the json-schema library expects 'optional'
+      // instead of 'required', which is from an older version of the spec.
+      schema['optional'] = !schema['required']
     } else if (typeof schema[key] === 'object') {
       // We ignore special keys in the next layer if:
       // 1) we are not in an "ignoreSpecialKeys" layer, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falkor",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "keywords": [
     "javascript",
     "nodeunit",


### PR DESCRIPTION
Hello dan, 

Please review the following commits I made in branch 'sho-multiple-json'.

5c2d3f8316737fc6d4a2a2dcb226f452d726278b (2012-10-23 18:39:17 -0700)
special handling of "required"

0db85ffdcca43f4e07df14d009c645ae30c63876 (2012-10-23 08:52:24 -0700)
Allow JSON schema validation to use references to multiple files
update version #

responding to PR comments

R=dan
