### PR TITLE
Add content length header for non-GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Helper for setting the cookie header.  Can be called multiple times to set multi
 
 #### .withPayload(string)
 
-Specifies a string to be sent as the request payload/body.  Will be sent regardless of HTTP method.
+Specifies a string (assumed to be utf8) to be sent as the request payload/body.  Will be sent regardless of HTTP method.
 
 #### .withFormEncodedPayload(object)
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -90,11 +90,12 @@ Options.prototype.withCookie = function (name, value, options) {
 
 /**
  * Sets the request payload.
- * @param {string} body A string.
+ * @param {string} body A string (assumed to be utf8)
  * @return {Options} The instance.
  */
 Options.prototype.withPayload = function (payload) {
   this._payload = payload
+  this.withHeader('Content-Length', Buffer.byteLength(payload, 'utf8'))
   return this
 }
 
@@ -163,7 +164,7 @@ Options.prototype.expectStatusCode = function (statusCode) {
 Options.prototype.expectHeader = function (name, value) {
   name = name.toLowerCase() // node lowercases headers.
   this.evaluate(function (test, res) {
-    test.equals(res.headers[name], value, 'Expected "' + name + '" header to be "' + value + '"')
+    test.equals(res.headers[name], value, 'Expected "' + name + '" header to be "' + value + '", found ' + JSON.stringify(res.headers))
   })
   return this
 }

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -108,6 +108,15 @@ TestCase.prototype.run = function () {
     , headers: this.getHeaders()
   }
 
+  if (options.method === 'PUT' || options.method === 'POST') {
+    // When there is no payload, a content length may not have
+    // been set. This causes problems for certain servers (e.g., nginx),
+    // so we set it here.
+    if (!options.headers['Content-Length'] && !this._payload) {
+      options.headers['Content-Length'] = 0
+    }
+  }
+
   var httpLib = options.port == 443 ? https : http
 
   // Sends the request, with an optional payload.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falkor",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "keywords": [
     "javascript",
     "nodeunit",

--- a/tests/falkor_test.js
+++ b/tests/falkor_test.js
@@ -101,6 +101,7 @@ exports.testWithFormEncodedPayload = function (test) {
 
   mockTest.verifyResponse(nock('http://falkor.fake')
       .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+      .matchHeader('Content-Length', 14)
       .post('/testformencoded', 'a=%3D%26&b=xxx')
       .reply(200, ''))
 
@@ -410,6 +411,7 @@ exports.testTemplates = function (test) {
       .put('/templated', 'data')
       .matchHeader('Cookie', 'username=dan')
       .matchHeader('TestHeader', '1234')
+      .matchHeader('Content-Length', 4)
       .reply(200, 'prefix result'))
 
   template.newTestCase('http://falkor.fake/templated')
@@ -434,11 +436,13 @@ exports.testTemplateOverrides = function (test) {
   mockTest.verifyResponse(nock('http://falkor.fake')
       .post('/templated', 'data')
       .matchHeader('TestHeader', '1234')
+      .matchHeader('Content-Length', 4)
       .reply(200, ''))
 
   mockTest.verifyResponse(nock('http://falkor.fake')
       .post('/templated', 'data override')
       .matchHeader('TestHeader', '9876')
+      .matchHeader('Content-Length', 13)
       .reply(200, ''))
 
 


### PR DESCRIPTION
Hello dan, 

Please review the following commits I made in branch 'sho-multiple-json'.

9be0d743fb4fe347c99c6f9156f11fb56a3b8f75 (2012-10-24 16:49:12 -0700)
Add content length header for non-GET requests

R=dan
