### PR TITLE
Remove unknown getBaseUrl call

### DIFF
--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -280,7 +280,6 @@ TestCase.prototype._dumpInfo = function (res) {
   this._log('  Request URL:', this._url)
   this._log('  Request Method:', this._httpMethod || 'GET')
   this._log('  Status Code:', res.statusCode)
-  this._log('  Base URL:', this.getBaseUrl())
 
   if (this._payload) {
     this._log('  Request Payload:')


### PR DESCRIPTION
Hello @dpup, @nicks, 

Please review the following commits I made in branch 'vinny-remove-base-url'.

I was trying to debug some failing tests with `dump`, but it is broken:

``` js
 TypeError: Object #<TestCase> has no method 'getBaseUrl'
<stack trace hidden>
```

It seems it was added recently and not defined anywhere so I just removed
the line.

4744ededabfd55f19f82d6b57125a95707704687 (2014-05-22 17:38:20 -0700)
Remove unknown getBaseUrl call

R=@dpup
R=@nicks
