### PR TITLE
add support for https on non-standard ports and setting a custom certificate authority

### DIFF
--- a/bin/runner.js
+++ b/bin/runner.js
@@ -17,6 +17,7 @@ var Q = require('q')
 var Asserter = require('../lib/asserter')
 var falkor = require('falkor')
 var flags = require('flags')
+var fs = require('fs')
 
 flags.defineString('baseUrl', '', 'The base URL for sending requests')
 flags.defineBoolean('serial', false, 'Run the tests in serial instead of in parallel')
@@ -24,6 +25,7 @@ flags.defineInteger('timeoutSecs', 120, 'The timeout, in seconds')
 flags.defineString('testPattern', '',
     'A case-insensitive regular expression. ' +
     'We will only run a test if the file or test name matches')
+flags.defineString('certAuthority', '', 'File containing a custom CA for https requests')
 
 // For backwards compatibility.
 var firstArg = process.argv[2]
@@ -41,6 +43,10 @@ var serial = flags.get('serial')
 
 if (flags.get('baseUrl')) {
   falkor.setBaseUrl(flags.get('baseUrl'))
+}
+
+if (flags.get('certAuthority')) {
+  falkor.setCertAuthority(fs.readFileSync(flags.get('certAuthority')))
 }
 
 var count = 0

--- a/lib/falkor.js
+++ b/lib/falkor.js
@@ -96,6 +96,16 @@ falkor.setBaseUrl = function (url) {
 
 
 /**
+ * Sets a global Certificate Authority for making secure requests using a custom cert
+ * @param {string} ca
+ */
+falkor.setCertAuthority = function (ca) {
+  config.certAuthority = ca
+  return this
+}
+
+
+/**
  * Sets a global path from which schema paths are resolved.
  * @param {string} url
  */

--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -11,7 +11,7 @@ var util = require('util')
 var Q = require('q')
 
 var Options = require('./options')
-
+var config = require('./globalconfig')
 
 
 /**
@@ -175,6 +175,11 @@ TestCase.prototype._run = function () {
     , headers: this.getHeaders()
   }
 
+  // Set a custom Certificate Authority for making secure requests.
+  if (config.certAuthority) {
+    options['ca'] = config.certAuthority
+  }
+
   // When there is no payload, a content length may not have
   // been set. This causes problems for certain servers (e.g., nginx),
   // so we set it here.
@@ -182,7 +187,7 @@ TestCase.prototype._run = function () {
     options.headers['Content-Length'] = 0
   }
 
-  var httpLib = options.port == 443 ? https : http
+  var httpLib = url.protocol == 'https:' ? https : http
 
   var requestFunction = function () {
     // Sends the request, with an optional payload.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falkor",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "keywords": [
     "javascript",
     "nodeunit",

--- a/tests/falkor_test.js
+++ b/tests/falkor_test.js
@@ -49,6 +49,20 @@ exports.testRequestFailures = function (test) {
 }
 
 
+// Tests that an SSL requests uses https
+exports.testSsl = function (test) {
+  var mockTest = newMockTestWithNoAssertions(test)
+
+  mockTest.verifyResponse(nock('https://falkor.fake:8080')
+      .get('/secure')
+      .reply(200, ''))
+
+  new falkor.TestCase('https://falkor.fake:8080/secure')
+    .setAsserter(mockTest)
+    .done()
+}
+
+
 // Tests that the optional setup function gets called before the test, when defined
 exports.testUsingSetupWithRegularFunction = function (test) {
   var mockTest = newMockTestWithNoAssertions(test)


### PR DESCRIPTION
Hello @adrianlee44, @eduardoramirez, @xiao, 

Please review the following commits I made in branch 'kylewm/ca'.

9b1315271ddb82e677ece6cc4ebfeb2da717d5ca (2018-05-13 21:38:34 -0700)
add support for https on non-standard ports and setting a custom certificate authority

R=@adrianlee44
R=@eduardoramirez
R=@xiao